### PR TITLE
Fix french Amazon Polly voice 'Léa'.

### DIFF
--- a/homeassistant/components/tts/amazon_polly.py
+++ b/homeassistant/components/tts/amazon_polly.py
@@ -43,7 +43,7 @@ SUPPORTED_VOICES = [
     'Joey', 'Justin', 'Matthew', 'Ivy', 'Joanna', 'Kendra', 'Kimberly',
     'Salli',  # English
     'Geraint',  # English Welsh
-    'Mathieu', 'Celine', 'Léa',  # French
+    'Mathieu', 'Celine', 'Lea',  # French
     'Chantal',  # French Canadian
     'Hans', 'Marlene', 'Vicki',  # German
     'Aditi',  # Hindi


### PR DESCRIPTION
The accent must be removed (Léa -> Lea) just like the other voices (eg. Celine, Peneloppe) to match with Amazon voices ID. 
Fun fact: there is no alternative name for "Léa" on Amazon Polly documentation: https://docs.aws.amazon.com/en_us/polly/latest/dg/voicelist.html, probably just omitted.
Mitigation: alternative voices (with and without accents) can be put into `SUPPORTED_VOICES`, both `voice.get('Id')` and `voice.get('Name')` must be then checked for a match.
This fixes #19802.

## Description:


**Related issue:** fixes #19802


## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: amazon_polly
    aws_secret_access_key: !secret aws_secret_access_key
    aws_access_key_id: !secret aws_access_key_id
    region_name: eu-central-1
    voice: 'Lea'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
